### PR TITLE
bug(core): RadioButtonGroup not automatically selected

### DIFF
--- a/src/core/components/carbon/controlled-radio-button-group/controlled-radio-button-group.component.tsx
+++ b/src/core/components/carbon/controlled-radio-button-group/controlled-radio-button-group.component.tsx
@@ -29,7 +29,7 @@ const ControlledRadioButtonGroup = <T,>(
           }}
           id={props.name}
           ref={ref}
-          value={value}
+          defaultSelected={value}
         />
       )}
     />


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.

## Summary
Most of the React form hook controllable inputs automatically restore state from the controller, however for `RadioButtonGroup` it was restoring to a wrong prop.

