### PR TITLE
bug(core): restore inline loading & number input to defaults

### DIFF
--- a/src/core/components/tabs/vertical-tabs.scss
+++ b/src/core/components/tabs/vertical-tabs.scss
@@ -46,10 +46,6 @@
     padding: 0;
   }
 
-  :global(.cds--inline-loading__text) {
-    color: white
-  }
-
   :global(.cds--tab--list) {
     flex-direction: column;
   }
@@ -70,10 +66,6 @@
     font-weight: 600;
   }
 
-  :global(.cds--number) {
-    width: 68%;
-  }
-
   :global(.cds--tabs__nav-link) {
     &:active, &:focus {
       outline: 0 !important;
@@ -81,10 +73,6 @@
     }
 
     max-height: 4rem;
-  }
-
-  :global(.cds--multi-select__wrapper .cds--list-box__wrapper) {
-    width: 90% !important;
   }
 
   :global(.cds--col) {


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.

## Summary
Global styles of the vertical tabs were breaking `InlineLoading` and `NumberInput` default styles. This P.R fixes that.
